### PR TITLE
SRCH-800- upgrade Nokogiri gem due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     net-ssh (4.2.0)
     newrelic_rpm (4.2.0.334)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)


### PR DESCRIPTION
SRCH-800 - upgrade Nokogiri gem due to security vulnerability with Nokogiri gem. See
https://nvd.nist.gov/vuln/detail/CVE-2019-5477 for more details