### PR TITLE
SRCH-811 remove ruby 2.3 from test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ workflows:
   build_and_test:
     jobs:
       - build:
-          ruby_version: 2.3.8
-      - build:
+          name: 'ruby 2.5.5'
           ruby_version: 2.5.5
       - build:
+          name: 'ruby 2.6.2'
           ruby_version: 2.6.2


### PR DESCRIPTION
This PR:
- removes ruby 2.3 from the test matrix on CirclCi. Tests will be run against ruby 2.5 and 2.6.
- names the test jobs