### PR TITLE
Release 1.1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ workflows:
   build_and_test:
     jobs:
       - build:
-          ruby_version: 2.3.8
-      - build:
+          name: 'ruby 2.5.5'
           ruby_version: 2.5.5
       - build:
+          name: 'ruby 2.6.2'
           ruby_version: 2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
     net-ssh (4.2.0)
     newrelic_rpm (4.2.0.334)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)


### PR DESCRIPTION
[SRCH-808] - upgrade Nokogiri gem due to security vulnerability
[SRCH-811] - remove ruby 2.3 from test matrix