### PR TITLE
SRCH-1204 SRCH-1206 update importers to use Painless scripting

### DIFF
--- a/app/queries/album_detection.rb
+++ b/app/queries/album_detection.rb
@@ -81,7 +81,7 @@ class AlbumDetection
         json.histogram do
           json.script do
             json.source '_score'
-            json.lang 'groovy'
+            json.lang 'painless'
           end
           json.interval 2
           json.order do

--- a/app/queries/top_hits.rb
+++ b/app/queries/top_hits.rb
@@ -51,7 +51,7 @@ class TopHits
           # https://www.elastic.co/guide/en/elasticsearch/reference/2.0/breaking_20_scripting_changes.html#_scripting_syntax
           json.script do
             json.source '_score'
-            json.lang 'groovy'
+            json.lang 'painless'
           end
         end
       end

--- a/app/workers/flickr_photos_importer.rb
+++ b/app/workers/flickr_photos_importer.rb
@@ -69,7 +69,7 @@ class FlickrPhotosImporter
     if group_id.present?
       script[:params][:new_group] = group_id
       script[:source] += <<~SOURCE.squish
-        ctx._source.groups.add(params.new_group) ;
+        ctx._source.groups.add(params.new_group);
         ctx._source.groups = ctx._source.groups.stream().distinct().collect(Collectors.toList())
       SOURCE
     end

--- a/app/workers/flickr_photos_importer.rb
+++ b/app/workers/flickr_photos_importer.rb
@@ -62,7 +62,7 @@ class FlickrPhotosImporter
     FlickrPhoto.create(attributes, op_type: 'create')
   rescue Elasticsearch::Transport::Transport::Errors::Conflict
     script = {
-      source: 'ctx._source.popularity = params.new_popularity ;',
+      source: 'ctx._source.popularity = params.new_popularity;',
       lang: 'painless',
       params: { new_popularity: flickr_photo_structure.views }
     }

--- a/app/workers/flickr_photos_importer.rb
+++ b/app/workers/flickr_photos_importer.rb
@@ -62,13 +62,16 @@ class FlickrPhotosImporter
     FlickrPhoto.create(attributes, op_type: 'create')
   rescue Elasticsearch::Transport::Transport::Errors::Conflict
     script = {
-      source: 'ctx._source.popularity = new_popularity',
-      lang: 'groovy',
+      source: 'ctx._source.popularity = params.new_popularity ;',
+      lang: 'painless',
       params: { new_popularity: flickr_photo_structure.views }
     }
     if group_id.present?
       script[:params][:new_group] = group_id
-      script[:source] += '; ctx._source.groups=(ctx._source.groups+new_group).unique()'
+      script[:source] += <<~SOURCE.squish
+        ctx._source.groups.add(params.new_group) ;
+        ctx._source.groups = ctx._source.groups.stream().distinct().collect(Collectors.toList())
+      SOURCE
     end
     FlickrPhoto.gateway.update(flickr_photo_structure.id, script: script)
     nil


### PR DESCRIPTION
This PR updates the FlickrPhotosImporter and a couple of other scripts to use the Painless instead of Groovy scripting language, which has been deprecated. This should also resolve production failures due to the use of Groovy scripts, which are disabled in production.