### PR TITLE
SRCH-1241 run specs against Elasticsearch 6.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,21 +8,24 @@ executors:
     docker:
       - image: circleci/ruby:${RUBY_VERSION}
       - image: redis:3.2-alpine
-      - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+      - image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION}
         environment:
           - xpack.security.enabled: false
-          - script.inline: true
-          - script.stored: true
+          - discovery.type: single-node
     working_directory: ~/app
 
 jobs:
   build:
     environment:
       RUBY_VERSION: << parameters.ruby_version >>
+      ELASTICSEARCH_VERSION: << parameters.elasticsearch_version >>
     executor: test_executor
     parameters:
       ruby_version:
         type: string
+      elasticsearch_version:
+        type: string
+        default: 5.6.16
     steps:
       - checkout
       - run:
@@ -32,6 +35,7 @@ jobs:
             cp -p config/instagram.yml.example config/instagram.yml
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}
+      - run: gem install bundler:1.17.3
       - run:
           name: bundle install
           command: |
@@ -66,8 +70,15 @@ workflows:
   build_and_test:
     jobs:
       - build:
-          name: 'ruby 2.5.5'
+          name: 'ruby 2.5, ES 5.6'
           ruby_version: 2.5.5
       - build:
-          name: 'ruby 2.6.2'
+          name: 'ruby 2.5, ES 6.8'
+          ruby_version: 2.5.5
+          elasticsearch_version: 6.8.6
+      - build:
+          name: 'ruby 2.6, ES 5.6'
           ruby_version: 2.6.2
+      - build:
+          name: 'ruby 2.7, ES 5.6'
+          ruby_version: 2.7.0

--- a/app/models/concerns/aliased_index.rb
+++ b/app/models/concerns/aliased_index.rb
@@ -33,7 +33,12 @@ module AliasedIndex
     end
 
     def delete_all
-      Elasticsearch::Persistence.client.delete_by_query(index: alias_name, conflicts: :proceed, body: { query: { match_all: {} } })
+      refresh_index!
+      Elasticsearch::Persistence.client.delete_by_query(
+        index: alias_name,
+        conflicts: :proceed,
+        body: { query: { match_all: {} } }
+      )
     end
   end
 end

--- a/spec/workers/mrss_photos_importer_spec.rb
+++ b/spec/workers/mrss_photos_importer_spec.rb
@@ -7,7 +7,10 @@ describe MrssPhotosImporter do
   it { is_expected.to be_unique }
 
   describe '#perform' do
-    subject(:perform) { importer.perform(mrss_profile.name) }
+    subject(:perform) do
+      importer.perform(mrss_profile.name)
+      MrssPhoto.refresh_index!
+    end
 
     let(:mrss_profile) do
       MrssProfile.create({ id: mrss_url }, refresh: true)
@@ -35,7 +38,9 @@ describe MrssPhotosImporter do
 
       it 'indexes the expected content' do
         perform
-        photo = MrssPhoto.all.first
+        photo = MrssPhoto.find(
+          'http://www.nasa.gov/archive/archive/content/samantha-cristoforettis-birthday-celebration'
+        )
 
         expect(photo.id).to eq(
           'http://www.nasa.gov/archive/archive/content/samantha-cristoforettis-birthday-celebration'


### PR DESCRIPTION
This PR adds Elasticsearch 6.8 and Ruby 2.7 to the test matrix. ES 5.6 will remain the default in specs until we have upgraded to 6.8.