### PR TITLE
SRCH-1837 add Elasticsearch client logging to Rails log

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -4,6 +4,12 @@ development: &default
   user: ''
   password: ''
   number_of_shards: 1
+  log: true
+  log_level: 0
 
 test:
   <<: *default
+
+production:
+  # Changes to the production configuration must be
+  # made in the cookbooks

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -5,7 +5,7 @@ development: &default
   password: ''
   number_of_shards: 1
   log: true
-  log_level: 0
+  log_level: DEBUG
 
 test:
   <<: *default

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Elasticsearch::Persistence.client = Elasticsearch::Client.new(
-  log: Rails.env.development?,
+  log: Rails.configuration.elasticsearch['log'],
   hosts: Rails.configuration.elasticsearch['hosts'],
   user: Rails.configuration.elasticsearch['user'],
   password: Rails.configuration.elasticsearch['password'],
@@ -10,12 +10,14 @@ Elasticsearch::Persistence.client = Elasticsearch::Client.new(
   reload_connections: true
 )
 
-if Rails.env.development?
-  logger = ActiveSupport::Logger.new(STDERR)
-  logger.level = Logger::DEBUG
-  logger.formatter = proc { |_s, _d, _p, m| "\e[2m#{m}\n\e[0m" }
-  Elasticsearch::Persistence.client.transport.logger = logger
+logger = ActiveSupport::Logger.new("log/#{Rails.env}.log")
+logger.level = Rails.configuration.elasticsearch['log_level']
+logger.formatter = proc do |severity, time, _progname, msg|
+  "\e[2m[ES][#{time.utc.iso8601(6)}][#{severity}] #{msg}\n\e[0m"
+end
+Elasticsearch::Persistence.client.transport.logger = logger
 
+if Rails.env.development?
   puts 'Ensuring Elasticsearch development indexes and aliases are available....'
   Dir[Rails.root.join('app', 'models', '*.rb')].map do |f|
     klass = File.basename(f, '.*').camelize.constantize


### PR DESCRIPTION
@MyNameIsMissing , this is a simple change to allow the Elasticsearch client in ASIS to write logging information to the Rails log, making it easier for devs to see what's going on in ES for any given Rails activity. There will be a corresponding PR in the cookbooks to update the ES config for ASIS. If you aren't comfortable reviewing, feel free to reassign to @jmax-fearless .