### PR TITLE
SRCH-2219 - Remove Ruby 2.5 from ASIS CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,5 +77,8 @@ workflows:
           name: "Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>"
           matrix:
             parameters:
-              ruby_version: ["2.6.6"]
-              elasticsearch_version: ["6.8.15"]
+              ruby_version:
+                - 2.6.6
+                - 2.7.3
+              elasticsearch_version:
+                - 6.8.15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
         type: string
       elasticsearch_version:
         type: string
-        default: 6.8.15
     steps:
       - checkout
       - run:
@@ -69,17 +68,14 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - build:
-          name: 'ruby 2.5, ES 6.8'
-          ruby_version: 2.5.5
       # SRCH-1253
       # - build:
       #     name: 'ruby 2.5, ES 7.7'
       #     ruby_version: 2.5.5
       #     elasticsearch_version: 7.7.0
       - build:
-          name: 'ruby 2.6, ES 6.8'
-          ruby_version: 2.6.6
-      - build:
-          name: 'ruby 2.7, ES 6.8'
-          ruby_version: 2.7.0
+          name: "Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>"
+          matrix:
+            parameters:
+              ruby_version: ["2.6.6"]
+              elasticsearch_version: ["6.8.15"]


### PR DESCRIPTION
Removed all traces Ruby 2.5. Also switched parameters to matrix
syntax, and removed defaults for all parameters, since the matrix
should handle all values, and we _want_ it to blow up if that's not
happening.