### PR TITLE
Release 1.1.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (3.12.6)
+    puma (5.3.2)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-accept (0.4.5)
@@ -387,7 +388,7 @@ DEPENDENCIES
   mock_redis (~> 0.17.3)
   newrelic_rpm (~> 4.2.0.334)
   pry-rails
-  puma (~> 3.12)
+  puma (~> 5.3)
   rails (~> 5.2.0)
   rake (~> 12.3.2)
   redis-namespace (~> 1.6.0)


### PR DESCRIPTION
This is a follow-up to #94. That PR included the Gemfile.lock updates as a result of bundle update, but it did not include the Gemfile.lock updates as a result of bumping puma. This PR rights that wrong.