### PR TITLE
SRCH-2639 remove Ruby 2.6 from CircleCi matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.2.0
+  ruby: circleci/ruby@1.4.0
 
 jobs:
   build_and_test:
@@ -66,7 +66,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 2.6.6
                 - 2.7.5
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:


### PR DESCRIPTION
## Summary
SRCH-2639 remove Ruby 2.6 from CircleCi matrix
- use Ruby orb 1.4.0
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally. - N/A

- [x] Tests have been added or updated to cover the proposed changes. If not, please explain why tests aren't needed: - N/A
 
- [x] Automated checks pass, if applicable. If CodeClimate checks do not pass, explain reason for failures:
 
- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] Your target branch is `master`, `main`, or `production`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits)
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers