### PR TITLE
SRCH-1829 specify minimum_should_match

### DIFF
--- a/app/queries/top_hits.rb
+++ b/app/queries/top_hits.rb
@@ -205,6 +205,8 @@ class TopHits
         flickr_profiles_filter_child('owner', flickr_users, json)
         flickr_profiles_filter_child('groups', flickr_groups, json)
       end
+
+      json.minimum_should_match 1
     end
   end
 


### PR DESCRIPTION
## Summary
This PR resolves the following breaking change in Elasticsearch 7.x:
https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#_the_filter_context_has_been_removed

This change preserves the 6.x behavior by explicitly setting `minimum_should_match: 1`, which ES 7.x will no longer do automatically.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally.

- [x] Tests have been added or updated to cover the proposed changes. If not, please explain why tests aren't needed: The existing specs confirm that this is a non-breaking change.
 
- [x] Automated checks pass, if applicable. If CodeClimate checks do not pass, explain reason for failures:
 
- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. I propose that we skip manual testing for this change.

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] Your target branch is `master`, `main`, or `production`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits)
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers