### PR TITLE
SRCH-1841 remove spaces from image ids in specs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,8 @@ plugins:
     config:
       languages:
       - ruby
+    exclude_patterns:
+    - spec/
   fixme:
     enabled: true
   rubocop:

--- a/spec/models/flickr_album_detector_spec.rb
+++ b/spec/models/flickr_album_detector_spec.rb
@@ -7,22 +7,22 @@ describe FlickrAlbumDetector do
     before do
       5.times do |x|
         i = x + 1
-        FlickrPhoto.create(id: "photo #{i}", owner: 'owner1', tags: ['alpha', 'bravo', 'charlie', i.ordinalize],
+        FlickrPhoto.create(id: "photo#{i}", owner: 'owner1', tags: ['alpha', 'bravo', 'charlie', i.ordinalize],
                            title: "#{i.ordinalize} presidential visit to Mars",
                            description: "#{i.ordinalize} title from unverified data provided by the Bain News Service on the negatives or caption cards",
                            taken_at: Date.parse('2014-09-16'), popularity: 100 + i, url: "http://photo#{i}", thumbnail_url: "http://photo_thumbnail#{i}",
-                           album: "photo #{i}", groups: [])
+                           album: "photo#{i}", groups: [])
       end
       FlickrPhoto.refresh_index!
     end
 
-    let(:photo) { FlickrPhoto.find 'photo 1' }
+    let(:photo) { FlickrPhoto.find 'photo1' }
 
     it 'assigns them all to the same album' do
       AlbumDetector.detect_albums! photo
       5.times do |x|
         i = x + 1
-        expect(FlickrPhoto.find("photo #{i}").album).to eq('owner1:2014-09-16:photo 1')
+        expect(FlickrPhoto.find("photo#{i}").album).to eq('owner1:2014-09-16:photo1')
       end
     end
   end

--- a/spec/models/mrss_album_detector_spec.rb
+++ b/spec/models/mrss_album_detector_spec.rb
@@ -7,22 +7,22 @@ describe MrssAlbumDetector do
     before do
       5.times do |x|
         i = x + 1
-        MrssPhoto.create(id: "photo #{i}", mrss_names: %w[95 96], tags: ['alpha', 'bravo', 'charlie', i.ordinalize],
+        MrssPhoto.create(id: "photo#{i}", mrss_names: %w[95 96], tags: ['alpha', 'bravo', 'charlie', i.ordinalize],
                          title: "#{i.ordinalize} Aircrew members traverse SERE combat survival training challenges",
                          description: "#{i.ordinalize} Aircrew members simulate being captured by a mock adversary during a combat survival refresher course",
                          taken_at: Date.parse('2014-10-24'), popularity: 0, url: "http://photo#{i}", thumbnail_url: "http://photo_thumbnail#{i}",
-                         album: "photo #{i}")
+                         album: "photo#{i}")
       end
       MrssPhoto.refresh_index!
     end
 
-    let(:photo) { MrssPhoto.find 'photo 1' }
+    let(:photo) { MrssPhoto.find 'photo1' }
 
     it 'assigns them all to the same album' do
       AlbumDetector.detect_albums! photo
       5.times do |x|
         i = x + 1
-        expect(MrssPhoto.find("photo #{i}").album).to eq('95:96:2014-10-24:photo 1')
+        expect(MrssPhoto.find("photo#{i}").album).to eq('95:96:2014-10-24:photo1')
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR updates the album detector specs to ensure that the specs will pass on both Elasticsearch 6 & 7. This change papers over a change in functionality between ES 6 & 7, which is that an encoded `+` in a document id in a URL is converted to a space in ES 6, but is indexed as a `+` in ES 7. Per discussion in the ticket, we're not planning to make code changes to prepare for the change, as a very small number of documents would be affected.

I've also disabled Code Climate's `duplication` engine for specs. (This is in line with our configuration in search-gov. There's value to de-duping specs, but it can also slow down development and reduce spec readability. So we leave spec de-duping to the discretion of the developer.)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally. - N/A

- [x] Tests have been added or updated to cover the proposed changes. If not, please explain why tests aren't needed:
 
- [x] Automated checks pass, if applicable. If CodeClimate checks do not pass, explain reason for failures:
 
- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] Your target branch is `master`, `main`, or `production`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits)
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers