### PR TITLE
SRCH-1827 run specs against Elasticsearch 6 & 7 in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ jobs:
           order: rand
       - run:
           name: Report Test Results
-          environment:
-            CC_TEST_REPORTER_ID: 0643ac526557dd490bc6f0542cac608a8815d7538dd580261e67dd334c07cc87
           command: |
             ./cc-test-reporter after-build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1.7.1
 
 jobs:
   build_and_test:
@@ -27,7 +27,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Copying config files for Flickr
+          name: Copy config files for Flickr
           command: |
             cp -p config/flickr.yml.example config/flickr.yml
       # Install gems with Bundler
@@ -36,26 +36,24 @@ jobs:
           # CircleCi project: Project Settings > Environment Variables
           key: gems-ruby-<< parameters.ruby_version >>-v{{ .Environment.CACHE_VERSION }}
       - run:
-          name: Install Code Climate Test Reporter
+          name: Prepare Code Climate Test Reporter
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
+            ./cc-test-reporter before-build
       - run:
-          name: Waiting for Elasticsearch
+          name: Wait for Elasticsearch
           command: dockerize --wait http://localhost:9200 -timeout 1m
+      - ruby/rspec-test:
+          # Need to temporarily test with a particular seed? Use:
+          # order: rand:123
+          order: rand
       - run:
-          name: RSpec
+          name: Report Test Results
           environment:
             CC_TEST_REPORTER_ID: 0643ac526557dd490bc6f0542cac608a8815d7538dd580261e67dd334c07cc87
           command: |
-            ./cc-test-reporter before-build
-            bundle exec rspec spec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml
             ./cc-test-reporter after-build
-      - store_test_results:
-          path: ~/rspec
-      - store_artifacts:
-          path: ~/rspec
-          destination: ~/rspec
 
 workflows:
   build_and_test:
@@ -68,6 +66,5 @@ workflows:
                 - 2.7.5
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:
-                - 6.8.15
-                # not yet compatible with Elasticsearch 7.x
-                # https://cm-jira.usa.gov/browse/SRCH-1253
+                - 6.8.23
+                - 7.17.3

--- a/spec/models/album_detector_spec.rb
+++ b/spec/models/album_detector_spec.rb
@@ -8,7 +8,7 @@ describe AlbumDetector do
 
     let(:photo) do
       FlickrPhoto.create(
-        id: 'flickr photo',
+        id: 'flickr_photo',
         owner: 'owner1',
         tags: [],
         title: 'title1 earth',
@@ -37,7 +37,7 @@ describe AlbumDetector do
       it 'logs the error' do
         detect_albums
         expect(Rails.logger).to have_received(:error).
-          with("Unable to assign album to photo 'flickr photo': failure")
+          with("Unable to assign album to photo 'flickr_photo': failure")
       end
 
       it 'does not raise an error' do


### PR DESCRIPTION
## Summary
This PR updates our CircleCi configuration. It:
- adds Elasticsearch 7.17.3 to the test matrix
- bumps the ruby orb version
- refactors the configuration to use the `ruby/rspec-test` command from the orb
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally. - N/A

- [x] Tests have been added or updated to cover the proposed changes. If not, please explain why tests aren't needed: - No code changes
 
- [x] Automated checks pass, if applicable. If CodeClimate checks do not pass, explain reason for failures: There have been some intermittent spec failures for `spec/models/image_search_spec.rb:63`. I'm addressing those in a follow-up ticket.
 
- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] Your target branch is `master`, `main`, or `production`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits)
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers