### PR TITLE
SRCH-2987 prevent ImageSearch spec from failing intermittently

### DIFF
--- a/app/models/concerns/aliased_index.rb
+++ b/app/models/concerns/aliased_index.rb
@@ -53,8 +53,6 @@ module AliasedIndex
         conflicts: :proceed,
         body: { query: { match_all: {} } }
       )
-      # purge deleted documents from the index to avoid polluting tests
-      Elasticsearch::Persistence.client.indices.forcemerge(index: alias_name)
     end
   end
 end

--- a/spec/models/image_search_spec.rb
+++ b/spec/models/image_search_spec.rb
@@ -54,6 +54,11 @@ describe ImageSearch do
 
   context 'when search term yields no results but a similar spelling does have results' do
     before do
+      # This spec can fail intermittently due to cruft from deleted documents.
+      # To avoid this, we completely recreate the indices (see note in spec/rails_helper.rb):
+      TestServices.delete_es_indexes
+      TestServices.create_es_indexes
+
       FlickrPhoto.create(id: 'photo1', owner: 'owner1', tags: [], title: 'title1 earth', description: 'desc 1', taken_at: Date.current, popularity: 100, url: 'http://photo1', thumbnail_url: 'http://photo_thumbnail1', album: 'album1', groups: [])
       MrssPhoto.create(id: '123456', username: 'user1', tags: %w[tag1 tag2], title: 'photo of the cassini probe', taken_at: Date.current, popularity: 101, url: 'http://photo2', thumbnail_url: 'http://photo_thumbnail2', album: 'album2')
       MrssPhoto.refresh_index!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,10 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  # Between indivdual specs, we use the "AliasedIndex#delete_all" method to purge documents
+  # from the indices. This is significantly faster than recreating the indices each time.
+  # However, the deleted documents can leave behind cruft that can cause some specs to fail
+  # intermittently. The workaround for those specs is to fully recreate the indices as below.
   config.before(:suite) do
     TestServices.delete_es_indexes
     TestServices.create_es_indexes


### PR DESCRIPTION
## Summary
This is a follow-up to https://github.com/GSA/asis/pull/141. That fix masked a Heisenbug; the process of my poking around and verifying that my "fix" did the trick had the same effect as a `sleep`. To avoid actually adding a several-second `sleep` in the specs (in order to let ES's caching catch up), I've recreated the indices before that particular spec and added some comments to guide future devs.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:
 
#### Functionality Checks
 
- [x] Code is functional, as tested locally.

- [x] Tests have been added or updated to cover the proposed changes. If not, please explain why tests aren't needed:
 
- [x] Automated checks pass, if applicable. If CodeClimate checks do not pass, explain reason for failures:
 
- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] Your target branch is `master`, `main`, or `production`, or you have specified the reason for an alternate branch here:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits)
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers