### PR TITLE
SRCH-1825 Make ElasticSearch 7.x the default for development and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,5 +64,5 @@ workflows:
                 - 2.7.5
                 # not yet compatible with Ruby 3.x
               elasticsearch_version:
-                - 6.8.23
-                - 7.17.3
+                - 7.17.7
+                # not yet compatible with Elasticsearch 8

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We use bundler to manage gems. You can install bundler and other required gems l
 
 The required services (MySQL, Elasticsearch, & Redis) can be run using Docker. Refer to [search-services](https://github.com/GSA/search-services) for detailed instructions.
 
-The Elasticsearch services provided by `searchgov-services` is configured to run on the default port, [9200](http://localhost:9200/). To use a different host (with or without port) or set of hosts, set the `ES_HOSTS` environment variable. For example, use following command to run the specs using Elasticsearch running on `localhost:9207`:
+The Elasticsearch service provided by `searchgov-services` is configured to run on the default port, [9200](http://localhost:9200/). To use a different host (with or without port) or set of hosts, set the `ES_HOSTS` environment variable. For example, use following command to run the specs using Elasticsearch running on `localhost:9207`:
 
     ES_HOSTS=localhost:9207 bundle exec rspec spec
 


### PR DESCRIPTION
## Summary
This PR removes ElasticSearch 6.x from the CI matrix.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
