### PR TITLE
Release SRCH-6046 Remove hardcoded ruby version from deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,7 +14,6 @@ set :puma_error_log,         "#{release_path}/log/puma.error.log"
 set :puma_threads,            [ENV.fetch('ASIS_MIN_THREADS', ASIS_THREADS), ASIS_THREADS]
 set :puma_workers,            ENV.fetch('ASIS_WORKERS') { 0 }
 set :rails_env,              'production'
-set :rbenv_ruby,             '3.1.4'
 set :rbenv_type,             :user
 set :repo_url,               'https://github.com/GSA/asis.git'
 set :sidekiq_roles,          :app


### PR DESCRIPTION
## Summary

- SRCH-6046 Remove hardcoded ruby version from deploy.rb
